### PR TITLE
Address "new Buffer" deprecation notice.

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ OffsetBuffer.prototype.copy = function copy(target, targetOff, off, n) {
 
 OffsetBuffer.prototype.take = function take(n) {
   if (n === 0)
-    return new Buffer(0);
+    return Buffer.alloc(0);
 
   this.size -= n;
 
@@ -148,7 +148,7 @@ OffsetBuffer.prototype.take = function take(n) {
   }
 
   // Allocate and fill buffer
-  var out = new Buffer(n);
+  var out = Buffer.alloc(n);
   var toOff = 0;
   var startOff = this.offset;
   for (var i = 0; toOff !== n && i < this.buffers.length; i++) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "obuf",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obuf",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`new Buffer(size)` has been deprecated: https://nodejs.org/api/buffer.html#buffer_new_buffer_size). The suggested change is to use `Buffer.alloc` instead: https://nodejs.org/api/buffer.html#buffer_static_method_buffer_alloc_size_fill_encoding

Closes #3 
